### PR TITLE
(categories): League Champion Data

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"
+    kotlin("plugin.serialization") version "2.1.10"
     id("org.springframework.boot") version "3.4.1"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.diffplug.spotless") version "7.0.2"
@@ -23,11 +24,15 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("io.mockk:mockk:1.13.16")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/uw/cse403/floorit/config/ServiceConfig.kt
+++ b/src/main/kotlin/uw/cse403/floorit/config/ServiceConfig.kt
@@ -1,14 +1,13 @@
 package uw.cse403.floorit.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import kotlinx.serialization.json.Json
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.client.RestTemplate
 
 @Configuration
 class ServiceConfig {
-    @Bean fun objectMapper(): ObjectMapper = jacksonObjectMapper()
+    @Bean fun json(): Json = Json { ignoreUnknownKeys = true }
 
     @Bean fun restTemplate(): RestTemplate = RestTemplate()
 }

--- a/src/main/kotlin/uw/cse403/floorit/controllers/ChampionController.kt
+++ b/src/main/kotlin/uw/cse403/floorit/controllers/ChampionController.kt
@@ -2,17 +2,14 @@ package uw.cse403.floorit.controllers
 
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
+import uw.cse403.floorit.models.ChampionEventDTO
 import uw.cse403.floorit.services.ChampionsService
 
 @RestController
 class ChampionController(private val championService: ChampionsService) {
 
     @GetMapping("/champions")
-    fun getChampions(): Map<String, List<String>> {
-        val championMapping = championService.getChampionMappings()
-
-        return championMapping
-          .mapKeys { (_, championData) -> championData.title }
-          .mapValues { (_, championData) -> listOf(championData.name) }
+    fun getChampions(): ChampionEventDTO {
+        return championService.getChampionMappings() ?: ChampionEventDTO("", emptyMap())
     }
 }

--- a/src/main/kotlin/uw/cse403/floorit/exceptions/ChampionDataException.kt
+++ b/src/main/kotlin/uw/cse403/floorit/exceptions/ChampionDataException.kt
@@ -1,6 +1,0 @@
-package uw.cse403.floorit.exceptions
-
-class ChampionDataException(
-  override val message: String,
-  override val cause: Throwable? = null,
-) : RuntimeException(message, cause)

--- a/src/main/kotlin/uw/cse403/floorit/models/ChampionDTO.kt
+++ b/src/main/kotlin/uw/cse403/floorit/models/ChampionDTO.kt
@@ -1,9 +1,16 @@
 package uw.cse403.floorit.models
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class Champion(val name: String, val title: String)
+@Serializable
+data class ChampionEventDTO(val version: String, val data: Map<String, ChampionDTO>)
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class ChampionResponse(val data: Map<String, Champion>)
+@Serializable
+data class ChampionDTO(val name: String, val title: String, val image: ChampionImageDTO)
+
+@Serializable
+data class ChampionImageDTO(
+  val full: String,
+  @SerialName("sprite") val thumbnail: String,
+)

--- a/src/main/kotlin/uw/cse403/floorit/services/ChampionsService.kt
+++ b/src/main/kotlin/uw/cse403/floorit/services/ChampionsService.kt
@@ -11,14 +11,16 @@ class ChampionsService(
   private val json: Json,
   private val restTemplate: RestTemplate, // TODO: change to webflux in future ticket
 ) {
+    companion object {
+        const val VERSION = "15.2.1"
+    }
+
     /**
-     * Fetches the list of champions from LoL champion API endpoint.
-     *
-     * @return a mapping of champion names to their champion data
+     * Fetches and parses a [ChampionEventDTO]
      */
     fun getChampionMappings(): ChampionEventDTO? {
         val url =
-          "https://ddragon.leagueoflegends.com/cdn/15.2.1/data/en_US/champion.json"
+          "https://ddragon.leagueoflegends.com/cdn/$VERSION/data/en_US/champion.json"
 
         return try {
             val response = restTemplate.getForObject(url, String::class.java)

--- a/src/test/kotlin/uw/cse403/floorit/controller/ChampionControllerTest.kt
+++ b/src/test/kotlin/uw/cse403/floorit/controller/ChampionControllerTest.kt
@@ -1,0 +1,72 @@
+package uw.cse403.floorit.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import uw.cse403.floorit.controllers.ChampionController
+import uw.cse403.floorit.models.ChampionDTO
+import uw.cse403.floorit.models.ChampionEventDTO
+import uw.cse403.floorit.models.ChampionImageDTO
+import uw.cse403.floorit.services.ChampionsService
+
+@WebMvcTest(controllers = [ChampionController::class])
+class ChampionControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+    @MockkBean
+    lateinit var championsService: ChampionsService
+
+    companion object {
+        const val VERSION = "15.2.1"
+    }
+
+    @Test
+    fun `should get all champions`() {
+        val champions = mapOf(
+            "Aatrox" to ChampionDTO(
+                name = "Aatrox",
+                title = "The Darkin Blade",
+                image = ChampionImageDTO(
+                    full = "Aatrox.png",
+                    thumbnail = "champion0.png"
+                )
+            ),
+            "Ahri" to ChampionDTO(
+                name = "Ahri",
+                title = "The Nine-Tailed Fox",
+                image = ChampionImageDTO(
+                    full = "Ahri.png",
+                    thumbnail = "champion1.png"
+                )
+            )
+        )
+
+        every { (championsService.getChampionMappings())} returns ChampionEventDTO(
+            version = VERSION,
+            data = champions
+        )
+
+        mockMvc.perform(get("/champions"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.version").value(VERSION))
+            .andExpect(jsonPath("$.data.Aatrox.name").value("Aatrox"))
+            .andExpect(jsonPath("$.data.Ahri.name").value("Ahri"))
+    }
+
+    @Test
+    fun `empty response`() {
+        // Mock the service to return null
+        every { championsService.getChampionMappings() } returns null
+
+        // Perform the GET request and verify the response
+        mockMvc.perform(get("/champions"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data").isEmpty)
+    }
+}


### PR DESCRIPTION
## Description of Change

### Changes made: 
- Changed `/champions` endpoint to be top-level
- Added versioning
- Controller Tests
- Utilized kotlinx.serialization for native kotlin support rather than Jackson
- Migrated to Mockk and springmockk _(kotlin version)_ than Mockito _(java version)_

Setting up future backend project structure
- Derived endpoints
- Websockets
- Webflux
- Logging
- Singleton design pattern
- Depedency injection

## Ticket number and link

None

## Solution and Tests

There is a league of legends API that can be found [here](https://ddragon.leagueoflegends.com/cdn/15.2.1/data/en_US/champion.json) . For more information you can visit the LoL api website and see the complete API calls related to LoL champions. 

First we'll fetch the URL (/GET) and render it as a string to be converted to a ChampionEventDTO. Since we ignore any unknown fields, we have a natural filtering of data we need. 

Sending this data to the front-- we only need to retain version of champions and the championData (name, title, image). **This leads to possible categories of both LoL titles to names or LoL images to names** 

Tested all logic classes (Services/Controllers/Utils)

## Screenshots

<img width="512" alt="image" src="https://github.com/user-attachments/assets/7db6e6e7-6354-424c-bdbb-23a1b8ac7b59" />


Also removed semi colons from champion names such as `Vel'Koz`
<img width="350" alt="image" src="https://github.com/user-attachments/assets/fabce89b-17fe-49ee-85ce-fa136cbb6d08" />
