### PR TITLE
Added function to main that scans category_data then makes a new json…

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,9 +1,57 @@
 from backend.src.models.category_data_dto import QuestionType
 from backend.src.scripts.lol_champions import Champions
+from backend.src.utils.definitions import PUBLIC_DIR
+import os
+import json
+from backend.src.models.category_preview_dto import (
+    CategoryPreviewDTO,
+    CategoryPreviewListDTO,
+)
 
 
 def main():
+    create_category_data()
+    create_category_preview_list()
+
+
+def create_category_data():
+    """
+    Takes all the subclasses of Category and
+    turns them into JSONs in public/category_data
+    """
     Champions(QuestionType.TEXT).to_file()
+
+
+def create_category_preview_list():
+    """
+    Scans all the category data in public/category_data
+    """
+
+    combined_data = []
+    directory = PUBLIC_DIR / "category_data"
+    output_path = os.path.join(PUBLIC_DIR, "category_preview_list.json")
+
+    # Loop through all files in the directory
+    for filename in os.listdir(directory):
+        if filename.endswith(".json"):  # Process only JSON files
+            file_path = os.path.join(directory, filename)
+
+            with open(file_path, "r", encoding="utf-8") as file:
+                try:
+                    data = json.load(file)
+                    category_preview = CategoryPreviewDTO(
+                        name=data["name"],
+                        image=data["preview_img"],
+                        desc=data["preview_desc"],
+                    )
+                    combined_data.append(category_preview)
+                except json.JSONDecodeError as e:
+                    print(f"Error reading {filename}: {e}")
+
+        # Write combined data to output JSON
+        category_preview_list = CategoryPreviewListDTO(category_previews=combined_data)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(category_preview_list.model_dump_json(indent=2))
 
 
 if __name__ == "__main__":

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -50,6 +50,7 @@ def create_category_preview_list():
 
         # Write combined data to output JSON
         category_preview_list = CategoryPreviewListDTO(category_previews=combined_data)
+        # TODO: reformat code to reduce redundancy
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(category_preview_list.model_dump_json(indent=2))
 

--- a/frontend/public/category_preview_list.json
+++ b/frontend/public/category_preview_list.json
@@ -1,0 +1,9 @@
+{
+  "category_previews": [
+    {
+      "name": "LoL Champion Titles",
+      "image": "default-preview.png",
+      "desc": "Guess the LoL champion's name by their title!"
+    }
+  ]
+}


### PR DESCRIPTION

## Description of Change

Added function to main that will automatically scan public/category_data then make a list of category previews with the name, preview_img and preview_desc for each category_data and compile into one json file

## Motivation and Context

[ticket-Script to Create CategoryPreviewListDTO](https://github.com/apnguyen1/floor-it/issues/73)

## Current behavior

No function that does that

## New Behavior

![image](https://github.com/user-attachments/assets/fa424a70-5728-4d51-a5d4-571487fe8f03)

## How Has This Been Tested?
The output for one category has been checked visually, will test more extensively as we start to add more categories