### PR TITLE
(structure): Renaming GameContext

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import { HomeScreen } from './screens/Home/HomeScreen.tsx';
 import { AvatarScreen } from './screens/Avatars/AvatarScreen.tsx';
 import { CategoriesScreen } from './screens/Categories/CategoriesScreen.tsx';
 import { GameScreen } from './screens/Game/GameScreen.tsx';
-import { GameProvider } from './context/AppContext.tsx';
+import { AppProvider } from './context/AppContext.tsx';
 import { Box, Container } from '@mui/material';
 
 const ScreenRender: React.FC = () => {
@@ -30,7 +30,7 @@ const App: React.FC = () => {
   const url = '/img/app_background.png';
 
   return (
-    <GameProvider>
+    <AppProvider>
       <Box
         sx={{
           backgroundImage: `url(${url})`,
@@ -44,7 +44,7 @@ const App: React.FC = () => {
           <ScreenRender />
         </Container>
       </Box>
-    </GameProvider>
+    </AppProvider>
   );
 };
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import './styles/App.css';
-import { useGame } from './hooks/useGame.ts';
+import { useApp } from './hooks/useApp.ts';
 import { ScreenType } from './constants/screens.ts';
 import { HomeScreen } from './screens/Home/HomeScreen.tsx';
 import { AvatarScreen } from './screens/Avatars/AvatarScreen.tsx';
 import { CategoriesScreen } from './screens/Categories/CategoriesScreen.tsx';
 import { GameScreen } from './screens/Game/GameScreen.tsx';
-import { GameProvider } from './context/GameContext.tsx';
+import { GameProvider } from './context/AppContext.tsx';
 import { Box, Container } from '@mui/material';
 
 const ScreenRender: React.FC = () => {
-  const { screen } = useGame();
+  const { screen } = useApp();
 
   switch (screen) {
     case ScreenType.Home:

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -1,11 +1,5 @@
 import { createContext, ReactNode, useState } from 'react';
-
-type AppContextType = {
-  screen: string;
-  setScreen: (screen: string) => void;
-  players: { P1: string; P2: string };
-  setPlayers: (players: { P1: string; P2: string }) => void;
-};
+import { AppContextType } from '../types/context.type.ts';
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
 

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -1,13 +1,13 @@
 import { createContext, ReactNode, useState } from 'react';
 
-type GameContextType = {
+type AppContextType = {
   screen: string;
   setScreen: (screen: string) => void;
   players: { P1: string; P2: string };
   setPlayers: (players: { P1: string; P2: string }) => void;
 };
 
-const AppContext = createContext<GameContextType | undefined>(undefined);
+const AppContext = createContext<AppContextType | undefined>(undefined);
 
 const GameProvider = ({ children }: { children: ReactNode }) => {
   const [screen, setScreen] = useState('home');

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -9,7 +9,7 @@ type AppContextType = {
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
 
-const GameProvider = ({ children }: { children: ReactNode }) => {
+const AppProvider = ({ children }: { children: ReactNode }) => {
   const [screen, setScreen] = useState('home');
   const [players, setPlayers] = useState({ P1: '', P2: '' });
 
@@ -20,4 +20,4 @@ const GameProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export { AppContext, GameProvider };
+export { AppContext, AppProvider };

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -7,17 +7,17 @@ type GameContextType = {
   setPlayers: (players: { P1: string; P2: string }) => void;
 };
 
-const GameContext = createContext<GameContextType | undefined>(undefined);
+const AppContext = createContext<GameContextType | undefined>(undefined);
 
 const GameProvider = ({ children }: { children: ReactNode }) => {
   const [screen, setScreen] = useState('home');
   const [players, setPlayers] = useState({ P1: '', P2: '' });
 
   return (
-    <GameContext.Provider value={{ screen, setScreen, players, setPlayers }}>
+    <AppContext.Provider value={{ screen, setScreen, players, setPlayers }}>
       {children}
-    </GameContext.Provider>
+    </AppContext.Provider>
   );
 };
 
-export { GameContext, GameProvider };
+export { AppContext, GameProvider };

--- a/frontend/src/hooks/useApp.ts
+++ b/frontend/src/hooks/useApp.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { AppContext } from '../context/AppContext.tsx';
+
+export const useApp = () => {
+  const context = useContext(AppContext);
+  if (!context) throw new Error('useApp must be used to use');
+
+  return context;
+};

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -1,9 +1,0 @@
-import { useContext } from 'react';
-import { GameContext } from '../context/GameContext.tsx';
-
-export const useGame = () => {
-  const context = useContext(GameContext);
-  if (!context) throw new Error('useGame must be used to use');
-
-  return context;
-};

--- a/frontend/src/screens/Avatars/AvatarScreen.tsx
+++ b/frontend/src/screens/Avatars/AvatarScreen.tsx
@@ -1,9 +1,9 @@
-import { useGame } from '../../hooks/useGame.ts';
+import { useApp } from '../../hooks/useApp.ts';
 import { Button, Container, Typography } from '@mui/material';
 import { ScreenType } from '../../constants/screens.ts';
 
 export const AvatarScreen = () => {
-  const { setScreen } = useGame();
+  const { setScreen } = useApp();
 
   return (
     <Container>

--- a/frontend/src/screens/Categories/CategoriesScreen.tsx
+++ b/frontend/src/screens/Categories/CategoriesScreen.tsx
@@ -1,9 +1,9 @@
-import { useGame } from '../../hooks/useGame.ts';
+import { useApp } from '../../hooks/useApp.ts';
 import { Button, Container, Typography } from '@mui/material';
 import { ScreenType } from '../../constants/screens.ts';
 
 export const CategoriesScreen = () => {
-  const { setScreen } = useGame();
+  const { setScreen } = useApp();
 
   return (
     <Container>

--- a/frontend/src/screens/Home/HomeScreen.tsx
+++ b/frontend/src/screens/Home/HomeScreen.tsx
@@ -1,11 +1,11 @@
-import { useGame } from '../../hooks/useGame.ts';
+import { useApp } from '../../hooks/useApp.ts';
 import './Home.css';
 import { ScreenType } from '../../constants/screens.ts';
 import { Box, Button, Typography } from '@mui/material';
 import InfoModal from '../../utils/InfoModal.tsx';
 
 export const HomeScreen = () => {
-  const { setScreen } = useGame();
+  const { setScreen } = useApp();
 
   return (
     <Box

--- a/frontend/src/types/context.type.ts
+++ b/frontend/src/types/context.type.ts
@@ -1,0 +1,6 @@
+export type AppContextType = {
+  screen: string;
+  setScreen: (screen: string) => void;
+  players: { P1: string; P2: string };
+  setPlayers: (players: { P1: string; P2: string }) => void;
+};


### PR DESCRIPTION
## Description of Change

Changed all previous occurences of `GameContext` to `AppContext`

## Motivation and Context

I need a new context named `GameContext` for my game screen but it was taken by this, I need this to be changed. 

## Current behavior

Incorrect naming of original gameContext

## New Behavior

Renamed it to a more general name of AppContext since it is an app wide context

## How Has This Been Tested?

Runs correctly
