### PR TITLE
Script to automate construction of categories

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -35,7 +35,7 @@ def create_category_data():
         # Get the constructor parameters for the subclass
         init_params = inspect.signature(subclass.__init__).parameters
         # Check if 'question_type' is in the constructor parameters (excluding 'self')
-        if 'question_type' in init_params:
+        if "question_type" in init_params:
             # If it has 'question_type' in constructor, instantiate with both types
             categories.append(subclass(question_type=QuestionType.TEXT))
             categories.append(subclass(question_type=QuestionType.IMG))

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -32,15 +32,15 @@ def create_category_data():
     categories: List[Category] = []
 
     for subclass in Category.__subclasses__():
+        # Get the constructor parameters for the subclass
         init_params = inspect.signature(subclass.__init__).parameters
-        init_params = list(init_params.keys())[1:]  # Skip 'self'
-
-        if (
-            len(init_params) == 1
-        ):  # If it requires one argument, assume it's QuestionType
-            categories.append(subclass(QuestionType.TEXT))
-            categories.append(subclass(QuestionType.IMG))
+        # Check if 'question_type' is in the constructor parameters (excluding 'self')
+        if 'question_type' in init_params:
+            # If it has 'question_type' in constructor, instantiate with both types
+            categories.append(subclass(question_type=QuestionType.TEXT))
+            categories.append(subclass(question_type=QuestionType.IMG))
         else:
+            # If not, just instantiate without parameters
             categories.append(subclass())
 
     # Call to_file() on all instances

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -11,8 +11,6 @@ from backend.src.models.category_preview_dto import (
     CategoryPreviewDTO,
     CategoryPreviewListDTO,
 )
-from backend.src.scripts.lol_champions import Champions
-from backend.src.scripts.numbers import Numbers
 from backend.src.utils.definitions import PUBLIC_DIR, SCRIPTS_DIR
 
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,9 +1,12 @@
 from backend.src.models.category_data_dto import QuestionType
-from backend.src.scripts.lol_champions import Champions
-from backend.src.scripts.numbers import Numbers
-from backend.src.utils.definitions import PUBLIC_DIR
+from backend.src.utils.definitions import PUBLIC_DIR, SCRIPTS_DIR
+from backend.src.utils.category import Category
+from typing import List
 import os
 import json
+import inspect
+import pkgutil
+import importlib
 from backend.src.models.category_preview_dto import (
     CategoryPreviewDTO,
     CategoryPreviewListDTO,
@@ -20,8 +23,29 @@ def create_category_data():
     Takes all the subclasses of Category and
     turns them into JSONs in public/category_data
     """
-    Champions(QuestionType.TEXT).to_file()
-    Numbers().to_file()
+
+    # Import all the files under scripts,
+    # since we need those to be imported to be recognized as subclasses
+    for _, module_name, _ in pkgutil.iter_modules([SCRIPTS_DIR]):
+        importlib.import_module(f"backend.src.scripts.{module_name}")
+    # Dynamically instantiate subclasses
+    categories: List[Category] = []
+
+    for subclass in Category.__subclasses__():
+        init_params = inspect.signature(subclass.__init__).parameters
+        init_params = list(init_params.keys())[1:]  # Skip 'self'
+
+        if (
+            len(init_params) == 1
+        ):  # If it requires one argument, assume it's QuestionType
+            categories.append(subclass(QuestionType.TEXT))
+            categories.append(subclass(QuestionType.IMG))
+        else:
+            categories.append(subclass())
+
+    # Call to_file() on all instances
+    for category in categories:
+        category.to_file()
 
 
 def create_category_preview_list():

--- a/backend/src/scripts/brand_icons.py
+++ b/backend/src/scripts/brand_icons.py
@@ -6,8 +6,14 @@ from backend.src.models.category_data_dto import QuestionType
 
 
 class BrandIcons(Category[BrandIconsDTO]):
-    def __init__(self, file: str):
-        super().__init__(file, BrandIconsDTO, QuestionType.IMG)
+    def __init__(self):
+        super().__init__(
+            source="brand-icons.json",
+            model=BrandIconsDTO,
+            question_type=QuestionType.IMG,
+            name="Brand Logos",
+            desc="Guess the brand by their logo!",
+        )
 
     def brand_logo_to_name(self) -> dict:
         return {q.partial: q.answers for q in self._raw_data.questions}

--- a/backend/src/scripts/brand_icons.py
+++ b/backend/src/scripts/brand_icons.py
@@ -6,9 +6,9 @@ from backend.src.models.category_data_dto import QuestionType
 
 
 class BrandIcons(Category[BrandIconsDTO]):
-    def __init__(self):
+    def __init__(self, file: str = "brand-icons.json"):
         super().__init__(
-            source="brand-icons.json",
+            source=file,
             model=BrandIconsDTO,
             question_type=QuestionType.IMG,
             name="Brand Logos",

--- a/backend/src/scripts/lol_champions.py
+++ b/backend/src/scripts/lol_champions.py
@@ -6,9 +6,9 @@ from backend.src.utils.category import Category
 
 
 class Champions(Category[ChampionDTO]):
-    def __init__(self, qt: QuestionType):
+    def __init__(self, question_type: QuestionType):
         url = "https://ddragon.leagueoflegends.com/cdn/15.2.1/data/en_US/champion.json"
-        super().__init__(source=url, model=ChampionDTO, question_type=qt)
+        super().__init__(source=url, model=ChampionDTO, question_type=question_type)
 
     def __title_to_name(self) -> Dict[str, List[str]]:
         """

--- a/backend/src/utils/definitions.py
+++ b/backend/src/utils/definitions.py
@@ -4,4 +4,6 @@ ROOT_DIR = Path(__file__).parent.parent.parent.parent
 
 RESOURCE_DIR = ROOT_DIR / "backend/src/resources"
 
+SCRIPTS_DIR = ROOT_DIR / "backend/src/scripts"
+
 PUBLIC_DIR = ROOT_DIR / "frontend/public"

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -3,5 +3,6 @@
   "semi": true,
   "trailingComma": "all",
   "tabWidth": 2,
-  "printWidth": 88
+  "printWidth": 88,
+  "endOfLine": "crlf"
 }

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -4,5 +4,5 @@
   "trailingComma": "all",
   "tabWidth": 2,
   "printWidth": 88,
-  "endOfLine": "crlf"
+  "endOfLine": "lf"
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -20,7 +20,7 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
-      'linebreak-style': ['error', 'lf'],
+      'linebreak-style': ['error', 'unix'],
     },
   },
 );

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -20,6 +20,7 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      'linebreak-style': ['error', 'lf'],
     },
   },
 );

--- a/frontend/public/category_data/brand_logos.json
+++ b/frontend/public/category_data/brand_logos.json
@@ -1,0 +1,585 @@
+{
+  "name": "Brand Logos",
+  "preview_img": "default-preview.png",
+  "preview_desc": "Guess the brand by their logo!",
+  "type": "img",
+  "questions": [
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Champion.png",
+      "answers": ["Champion", "Champyon", "Champion Sport", "Champion Clothing"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Sony.png",
+      "answers": [
+        "Sony",
+        "Sony Entertainment",
+        "Sony Ericsson",
+        "Sow Knee",
+        "Sue Nee",
+        "Sue Knee"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Bitcoin.png",
+      "answers": [
+        "Bitcoin",
+        "BTC",
+        "Bitcoin Mining",
+        "Bitcoin Currency",
+        "Be Te See",
+        "Bee Tee See",
+        "Bee Tea See",
+        "Bee Tee Sea",
+        "Bee Tee Cee"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Asos.png",
+      "answers": ["ASOS", "Ay Sos", "Asos dot Com", "Ey Sos", "Ay Es O ES", "Aye Sos"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Soundcloud.png",
+      "answers": [
+        "Soundcloud",
+        "Soundcloud Go",
+        "Soundcloud Streaming",
+        "Soundcloud Music",
+        "Sound Loud",
+        "Sand Cloud"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Ebay.png",
+      "answers": ["Ebay", "E Bay", "Ee Bay", "Ey Bay", "Ay Bay"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Anker.png",
+      "answers": ["Anker", "Anchor", "An Kar", "An Kur"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Playstation.png",
+      "answers": [
+        "Playstation",
+        "Play Station",
+        "PlayStation Console",
+        "PS",
+        "Pee Ess",
+        "Pee Ess Two",
+        "Pee Ess Three",
+        "Pee Ess Four"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Xbox.png",
+      "answers": [
+        "Xbox",
+        "Xbox 360",
+        "Xbox One",
+        "Xbox Live",
+        "Eggs Box",
+        "Ex Box",
+        "Acks Box",
+        "Axe Box"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Kappa.png",
+      "answers": ["Kappa", "Kappa Clothing", "Kappa Brand", "Cap Pa", "Kippa", "Capar"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Wikipedia.png",
+      "answers": [
+        "Wikipedia",
+        "Wick Ay Pedi Ay",
+        "Wika Pedia",
+        "Wuki Pedia",
+        "Wiki Pee Dia"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Dodge.png",
+      "answers": [
+        "Dodge",
+        "Dodge Challenger",
+        "Dodge Viper",
+        "Dodge Muscle Cars",
+        "Dodge Vehicles"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Ford.png",
+      "answers": ["Ford", "Ford Cars", "Ford Auto", "Ford Motors"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Adidas.png",
+      "answers": [
+        "Adidas",
+        "A Deed Ass",
+        "Add Idas",
+        "Adidas Originals",
+        "Adidas Clothing"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Bing.png",
+      "answers": ["Bing", "Ping", "Bing Search"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Twitch.png",
+      "answers": ["Twitch", "Twitch dot TV", "Twitch dot Tee Vee"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Capcom.png",
+      "answers": ["Capcom", "Cap Com", "Capcom Games"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Crunchyroll.png",
+      "answers": [
+        "Crunchyroll",
+        "Crunchy Roll",
+        "Crunchyroll Anime",
+        "Crunchy Roll Anime",
+        "Crunchyroll Manga",
+        "Crunchy Roll Manga"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Tesla.png",
+      "answers": ["Tesla", "Tesla Motors", "Testla"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Lexus.png",
+      "answers": ["Lexus", "Lexus Motors", "Lecks Us", "Leck Suse"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Toyota.png",
+      "answers": ["Toyota", "Toyota Motors", "Toy Yoda", "Toy Yoda Motors"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/McDoanlds.png",
+      "answers": [
+        "McDonalds",
+        "McDonalds Corporation",
+        "McDonalds Restaurant",
+        "Mac Donalds",
+        "Mac Donalds Restaurant",
+        "Mac Donalds Corporation"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/KFC.png",
+      "answers": [
+        "KFC",
+        "KFC Restaurants",
+        "KFC Chicken",
+        "Kay Eff Cee",
+        "Kay Eff Cee Chicken",
+        "Kay Eff Cee Restaurants"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Coke.png",
+      "answers": ["Coke", "Coca Cola", "Coke A Cola"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Patagonia.png",
+      "answers": [
+        "Patagonia",
+        "Patagonia Clothing",
+        "Patagonia Outdoor",
+        "Pat Ay Gonia",
+        "Pat Ay Gonia Clothing",
+        "Pat Ay Gonia Outdoor",
+        "Pat Ee Gonia",
+        "Pat Ee Gonia Clothing",
+        "Pat Ee Gonia Outdoor"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/YSL.png",
+      "answers": [
+        "YSL",
+        "Yves Saint Laurent",
+        "Saint Laurent",
+        "Yes Saint Laurent",
+        "Why Es El"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Lamborghini.png",
+      "answers": ["Lamborghini", "Lambo", "Lamb Or Ghini", "Lumborghini"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Dominos.png",
+      "answers": ["Dominos", "Domino", "Dominos Pizza", "Domino Pizza"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Monster.png",
+      "answers": ["Monster", "Monster Energy", "Monster Energy Drink"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/LG.png",
+      "answers": [
+        "LG",
+        "LG Electronics",
+        "El Gee",
+        "El Gee Electronics",
+        "Lifes Good",
+        "Lucky Goldstar"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Rayban.png",
+      "answers": [
+        "Rayban",
+        "Ray Ban",
+        "Rayban Sunglasses",
+        "Ray Ban Sunglasses",
+        "Rayban by Luxotica",
+        "Ray Ban by Luxotica",
+        "RayBan Eyewear",
+        "Ray Ban Eyewear",
+        "Rayban Brand",
+        "Ray Ban Brand"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Nike.png",
+      "answers": [
+        "Nike",
+        "Ni Key",
+        "Nay Key",
+        "Nike Clothing",
+        "Ni Key Clothing",
+        "Nay Key Clothing",
+        "Nike Shoes",
+        "Ni Key SHoes",
+        "Nay Key Shoes"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/PizzaHut.png",
+      "answers": ["Pizza Hut", "Pizza the Hut", "Piece Of Hut"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Starbucks.png",
+      "answers": [
+        "Starbucks",
+        "Star Bucks",
+        "Starbooks",
+        "Star Books",
+        "Star Books Coffee",
+        "Star Bucks Coffee",
+        "Starbucks Coffee"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Subway.png",
+      "answers": ["Subway", "subway sandwiches", "sub way", "sub way sandwhiches"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/BMW.png",
+      "answers": [
+        "BMW",
+        "b m w",
+        "bee em double u",
+        "bee m w",
+        "bee m double u",
+        "bee mw"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Shell.png",
+      "answers": ["Shell", "Royal Dutch Shell"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Apple.png",
+      "answers": ["Apple", "Apple inc", "Apple Computers"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Honda.png",
+      "answers": ["Honda", "Hon Da", "Hon Dar"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Volkswagen.png",
+      "answers": [
+        "Volkswagen",
+        "volks wagon",
+        "folks wagon",
+        "folks wagen",
+        "volks wagen",
+        "volkswagon",
+        "folkswagon"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Samsung.png",
+      "answers": ["Samsung", "Samsang", "Samsun", "Samson"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Gucci.png",
+      "answers": ["Gucci", "Goochi", "Gu Chi", "Goo Chi", "Goo Chey", "Goochey"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/IBM.png",
+      "answers": ["IBM", "Eye Bee Em", "IBeeM", "IBEm", "I Bee Em", "IBee Em"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Intel.png",
+      "answers": [
+        "Intel",
+        "Intell",
+        "In Tel",
+        "In Tell",
+        "Inn Tell",
+        "Intel Computers"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Facebook.png",
+      "answers": [
+        "Facebook",
+        "Facebook Dot Com",
+        "Face Book",
+        "Phase Book",
+        "Face Buck",
+        "Phase Buck"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Twitter.png",
+      "answers": [
+        "Twitter",
+        "Twitter Dot Com",
+        "Twittir",
+        "Twittar",
+        "Tweetar",
+        "Tweetir"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Snapchat.png",
+      "answers": ["Snapchat", "Snap Chat", "Snapchat Dot Com"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Nintendo.png",
+      "answers": [
+        "Nintendo",
+        "Nintendo Corporation",
+        "Nintendo Company",
+        "Nin Tendo",
+        "nine tendo"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Playboy.png",
+      "answers": ["Playboy", "play boy", "ploy boy", "ploo boy", "plooboy", "ployboy"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Amazon.png",
+      "answers": ["Amazon", "Amazon Dot Com", "Amazon Shopping", "Amazon Online"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Skype.png",
+      "answers": [
+        "Skype",
+        "Skype Dot Com",
+        "Skype Video",
+        "Skype Audio",
+        "Sky Pee",
+        "Sky P"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Nvidia.png",
+      "answers": ["Nvidia", "Nvidia Gaming", "Nvidia Graphics", "NVideoya", "NVidi Ya"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/AMD.png",
+      "answers": ["AMD", "Ay Em Dee", "AMDee", "AyM Dee", "AEmDee", "ay m Dee"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Supreme.png",
+      "answers": [
+        "Supreme",
+        "Supreme Clothing",
+        "Supreme Skateboards",
+        "Supreme Skateboarding",
+        "Suprem"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Visa.png",
+      "answers": ["Visa", "Vee Sa", "Veesa", "Viza", "Vi Za", "Visa Card", "Viza Card"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/BankOfAmerica.png",
+      "answers": [
+        "bank of america",
+        "bank of ameerica",
+        "bank of ameer ica",
+        "bank of american",
+        "bankof america",
+        "bankof ameer ica"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Porsche.png",
+      "answers": ["Porsche", "porsh", "pourche", "porscher", "pour che"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Jaguar.png",
+      "answers": ["Jaguar", "Jag guar", "ja guar", "jag gwar", "ja gwar"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/RedBull.png",
+      "answers": [
+        "Red Bull",
+        "redbull",
+        "red bully",
+        "red bule",
+        "red bulls",
+        "bed bull"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/DreamWorks.png",
+      "answers": [
+        "DreamWorks",
+        "Dream Works",
+        "dreem work",
+        "dream work",
+        "dreamworks studios",
+        "dream works studios"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Timberland.png",
+      "answers": [
+        "Timberland",
+        "Timber land",
+        "tim ber land",
+        "tim berland",
+        "tomberland",
+        "tom ber lan",
+        "tom ber land"
+      ],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Netflix.png",
+      "answers": ["Netflix", "Net flix", "net flicks", "netflicks", "net flick"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Spotify.png",
+      "answers": ["Spotify", "Spotify Dot Com", "Spotify Music", "Spot Ify", "Spatafy"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Balenciaga.png",
+      "answers": ["Balenciaga", "Balance Ciaga", "Balen Ciaga"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/ADT.png",
+      "answers": ["ADT Security", "Ay Dee Tee", "ADee Tee", "Ay Dee Tea"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Steam.png",
+      "answers": ["Steam", "Steem", "Stem", "Stee M"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Github.png",
+      "answers": ["Github", "Jithub", "Get Hub", "Gut Hub", "Githab"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Ubisoft.png",
+      "answers": ["Ubisoft", "U Bee Soft", "You Be Soft", "Yu Be Soft"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Google.png",
+      "answers": ["Google", "Goo Gol", "Goo Gul", "Goggle"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Superdry.png",
+      "answers": ["Superdry", "Soup Her Dry", "Super Dri"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Airbnb.png",
+      "answers": ["Airbnb", "Air B and B", "Air B En B", "Air B on B"],
+      "aliases": []
+    },
+    {
+      "question": "https://raw.githubusercontent.com/fuzzysb/Logo-Quiz-Logos/master/Logos/Uber.png",
+      "answers": ["Uber", "Ou Ber", "Ou Bear", "U Ber", "U Bear"],
+      "aliases": []
+    }
+  ]
+}

--- a/frontend/public/category_data/lol_champion_covers.json
+++ b/frontend/public/category_data/lol_champion_covers.json
@@ -1,0 +1,858 @@
+{
+  "name": "LoL Champion Covers",
+  "preview_img": "default-preview.png",
+  "preview_desc": "Guess the LoL champion's name by their image!",
+  "type": "img",
+  "questions": [
+    {
+      "question": "Aatrox.png",
+      "answers": ["Aatrox"],
+      "aliases": []
+    },
+    {
+      "question": "Ahri.png",
+      "answers": ["Ahri"],
+      "aliases": []
+    },
+    {
+      "question": "Akali.png",
+      "answers": ["Akali"],
+      "aliases": []
+    },
+    {
+      "question": "Akshan.png",
+      "answers": ["Akshan"],
+      "aliases": []
+    },
+    {
+      "question": "Alistar.png",
+      "answers": ["Alistar"],
+      "aliases": []
+    },
+    {
+      "question": "Ambessa.png",
+      "answers": ["Ambessa"],
+      "aliases": []
+    },
+    {
+      "question": "Amumu.png",
+      "answers": ["Amumu"],
+      "aliases": []
+    },
+    {
+      "question": "Anivia.png",
+      "answers": ["Anivia"],
+      "aliases": []
+    },
+    {
+      "question": "Annie.png",
+      "answers": ["Annie"],
+      "aliases": []
+    },
+    {
+      "question": "Aphelios.png",
+      "answers": ["Aphelios"],
+      "aliases": []
+    },
+    {
+      "question": "Ashe.png",
+      "answers": ["Ashe"],
+      "aliases": []
+    },
+    {
+      "question": "AurelionSol.png",
+      "answers": ["Aurelion Sol"],
+      "aliases": []
+    },
+    {
+      "question": "Aurora.png",
+      "answers": ["Aurora"],
+      "aliases": []
+    },
+    {
+      "question": "Azir.png",
+      "answers": ["Azir"],
+      "aliases": []
+    },
+    {
+      "question": "Bard.png",
+      "answers": ["Bard"],
+      "aliases": []
+    },
+    {
+      "question": "Belveth.png",
+      "answers": ["Bel Veth"],
+      "aliases": []
+    },
+    {
+      "question": "Blitzcrank.png",
+      "answers": ["Blitzcrank"],
+      "aliases": []
+    },
+    {
+      "question": "Brand.png",
+      "answers": ["Brand"],
+      "aliases": []
+    },
+    {
+      "question": "Braum.png",
+      "answers": ["Braum"],
+      "aliases": []
+    },
+    {
+      "question": "Briar.png",
+      "answers": ["Briar"],
+      "aliases": []
+    },
+    {
+      "question": "Caitlyn.png",
+      "answers": ["Caitlyn"],
+      "aliases": []
+    },
+    {
+      "question": "Camille.png",
+      "answers": ["Camille"],
+      "aliases": []
+    },
+    {
+      "question": "Cassiopeia.png",
+      "answers": ["Cassiopeia"],
+      "aliases": []
+    },
+    {
+      "question": "Chogath.png",
+      "answers": ["Cho Gath"],
+      "aliases": []
+    },
+    {
+      "question": "Corki.png",
+      "answers": ["Corki"],
+      "aliases": []
+    },
+    {
+      "question": "Darius.png",
+      "answers": ["Darius"],
+      "aliases": []
+    },
+    {
+      "question": "Diana.png",
+      "answers": ["Diana"],
+      "aliases": []
+    },
+    {
+      "question": "Draven.png",
+      "answers": ["Draven"],
+      "aliases": []
+    },
+    {
+      "question": "DrMundo.png",
+      "answers": ["Dr. Mundo"],
+      "aliases": []
+    },
+    {
+      "question": "Ekko.png",
+      "answers": ["Ekko"],
+      "aliases": []
+    },
+    {
+      "question": "Elise.png",
+      "answers": ["Elise"],
+      "aliases": []
+    },
+    {
+      "question": "Evelynn.png",
+      "answers": ["Evelynn"],
+      "aliases": []
+    },
+    {
+      "question": "Ezreal.png",
+      "answers": ["Ezreal"],
+      "aliases": []
+    },
+    {
+      "question": "Fiddlesticks.png",
+      "answers": ["Fiddlesticks"],
+      "aliases": []
+    },
+    {
+      "question": "Fiora.png",
+      "answers": ["Fiora"],
+      "aliases": []
+    },
+    {
+      "question": "Fizz.png",
+      "answers": ["Fizz"],
+      "aliases": []
+    },
+    {
+      "question": "Galio.png",
+      "answers": ["Galio"],
+      "aliases": []
+    },
+    {
+      "question": "Gangplank.png",
+      "answers": ["Gangplank"],
+      "aliases": []
+    },
+    {
+      "question": "Garen.png",
+      "answers": ["Garen"],
+      "aliases": []
+    },
+    {
+      "question": "Gnar.png",
+      "answers": ["Gnar"],
+      "aliases": []
+    },
+    {
+      "question": "Gragas.png",
+      "answers": ["Gragas"],
+      "aliases": []
+    },
+    {
+      "question": "Graves.png",
+      "answers": ["Graves"],
+      "aliases": []
+    },
+    {
+      "question": "Gwen.png",
+      "answers": ["Gwen"],
+      "aliases": []
+    },
+    {
+      "question": "Hecarim.png",
+      "answers": ["Hecarim"],
+      "aliases": []
+    },
+    {
+      "question": "Heimerdinger.png",
+      "answers": ["Heimerdinger"],
+      "aliases": []
+    },
+    {
+      "question": "Hwei.png",
+      "answers": ["Hwei"],
+      "aliases": []
+    },
+    {
+      "question": "Illaoi.png",
+      "answers": ["Illaoi"],
+      "aliases": []
+    },
+    {
+      "question": "Irelia.png",
+      "answers": ["Irelia"],
+      "aliases": []
+    },
+    {
+      "question": "Ivern.png",
+      "answers": ["Ivern"],
+      "aliases": []
+    },
+    {
+      "question": "Janna.png",
+      "answers": ["Janna"],
+      "aliases": []
+    },
+    {
+      "question": "JarvanIV.png",
+      "answers": ["Jarvan IV"],
+      "aliases": []
+    },
+    {
+      "question": "Jax.png",
+      "answers": ["Jax"],
+      "aliases": []
+    },
+    {
+      "question": "Jayce.png",
+      "answers": ["Jayce"],
+      "aliases": []
+    },
+    {
+      "question": "Jhin.png",
+      "answers": ["Jhin"],
+      "aliases": []
+    },
+    {
+      "question": "Jinx.png",
+      "answers": ["Jinx"],
+      "aliases": []
+    },
+    {
+      "question": "Kaisa.png",
+      "answers": ["Kai Sa"],
+      "aliases": []
+    },
+    {
+      "question": "Kalista.png",
+      "answers": ["Kalista"],
+      "aliases": []
+    },
+    {
+      "question": "Karma.png",
+      "answers": ["Karma"],
+      "aliases": []
+    },
+    {
+      "question": "Karthus.png",
+      "answers": ["Karthus"],
+      "aliases": []
+    },
+    {
+      "question": "Kassadin.png",
+      "answers": ["Kassadin"],
+      "aliases": []
+    },
+    {
+      "question": "Katarina.png",
+      "answers": ["Katarina"],
+      "aliases": []
+    },
+    {
+      "question": "Kayle.png",
+      "answers": ["Kayle"],
+      "aliases": []
+    },
+    {
+      "question": "Kayn.png",
+      "answers": ["Kayn"],
+      "aliases": []
+    },
+    {
+      "question": "Kennen.png",
+      "answers": ["Kennen"],
+      "aliases": []
+    },
+    {
+      "question": "Khazix.png",
+      "answers": ["Kha Zix"],
+      "aliases": []
+    },
+    {
+      "question": "Kindred.png",
+      "answers": ["Kindred"],
+      "aliases": []
+    },
+    {
+      "question": "Kled.png",
+      "answers": ["Kled"],
+      "aliases": []
+    },
+    {
+      "question": "KogMaw.png",
+      "answers": ["Kog Maw"],
+      "aliases": []
+    },
+    {
+      "question": "KSante.png",
+      "answers": ["K Sante"],
+      "aliases": []
+    },
+    {
+      "question": "Leblanc.png",
+      "answers": ["LeBlanc"],
+      "aliases": []
+    },
+    {
+      "question": "LeeSin.png",
+      "answers": ["Lee Sin"],
+      "aliases": []
+    },
+    {
+      "question": "Leona.png",
+      "answers": ["Leona"],
+      "aliases": []
+    },
+    {
+      "question": "Lillia.png",
+      "answers": ["Lillia"],
+      "aliases": []
+    },
+    {
+      "question": "Lissandra.png",
+      "answers": ["Lissandra"],
+      "aliases": []
+    },
+    {
+      "question": "Lucian.png",
+      "answers": ["Lucian"],
+      "aliases": []
+    },
+    {
+      "question": "Lulu.png",
+      "answers": ["Lulu"],
+      "aliases": []
+    },
+    {
+      "question": "Lux.png",
+      "answers": ["Lux"],
+      "aliases": []
+    },
+    {
+      "question": "Malphite.png",
+      "answers": ["Malphite"],
+      "aliases": []
+    },
+    {
+      "question": "Malzahar.png",
+      "answers": ["Malzahar"],
+      "aliases": []
+    },
+    {
+      "question": "Maokai.png",
+      "answers": ["Maokai"],
+      "aliases": []
+    },
+    {
+      "question": "MasterYi.png",
+      "answers": ["Master Yi"],
+      "aliases": []
+    },
+    {
+      "question": "Mel.png",
+      "answers": ["Mel"],
+      "aliases": []
+    },
+    {
+      "question": "Milio.png",
+      "answers": ["Milio"],
+      "aliases": []
+    },
+    {
+      "question": "MissFortune.png",
+      "answers": ["Miss Fortune"],
+      "aliases": []
+    },
+    {
+      "question": "MonkeyKing.png",
+      "answers": ["Wukong"],
+      "aliases": []
+    },
+    {
+      "question": "Mordekaiser.png",
+      "answers": ["Mordekaiser"],
+      "aliases": []
+    },
+    {
+      "question": "Morgana.png",
+      "answers": ["Morgana"],
+      "aliases": []
+    },
+    {
+      "question": "Naafiri.png",
+      "answers": ["Naafiri"],
+      "aliases": []
+    },
+    {
+      "question": "Nami.png",
+      "answers": ["Nami"],
+      "aliases": []
+    },
+    {
+      "question": "Nasus.png",
+      "answers": ["Nasus"],
+      "aliases": []
+    },
+    {
+      "question": "Nautilus.png",
+      "answers": ["Nautilus"],
+      "aliases": []
+    },
+    {
+      "question": "Neeko.png",
+      "answers": ["Neeko"],
+      "aliases": []
+    },
+    {
+      "question": "Nidalee.png",
+      "answers": ["Nidalee"],
+      "aliases": []
+    },
+    {
+      "question": "Nilah.png",
+      "answers": ["Nilah"],
+      "aliases": []
+    },
+    {
+      "question": "Nocturne.png",
+      "answers": ["Nocturne"],
+      "aliases": []
+    },
+    {
+      "question": "Nunu.png",
+      "answers": ["Nunu & Willump"],
+      "aliases": []
+    },
+    {
+      "question": "Olaf.png",
+      "answers": ["Olaf"],
+      "aliases": []
+    },
+    {
+      "question": "Orianna.png",
+      "answers": ["Orianna"],
+      "aliases": []
+    },
+    {
+      "question": "Ornn.png",
+      "answers": ["Ornn"],
+      "aliases": []
+    },
+    {
+      "question": "Pantheon.png",
+      "answers": ["Pantheon"],
+      "aliases": []
+    },
+    {
+      "question": "Poppy.png",
+      "answers": ["Poppy"],
+      "aliases": []
+    },
+    {
+      "question": "Pyke.png",
+      "answers": ["Pyke"],
+      "aliases": []
+    },
+    {
+      "question": "Qiyana.png",
+      "answers": ["Qiyana"],
+      "aliases": []
+    },
+    {
+      "question": "Quinn.png",
+      "answers": ["Quinn"],
+      "aliases": []
+    },
+    {
+      "question": "Rakan.png",
+      "answers": ["Rakan"],
+      "aliases": []
+    },
+    {
+      "question": "Rammus.png",
+      "answers": ["Rammus"],
+      "aliases": []
+    },
+    {
+      "question": "RekSai.png",
+      "answers": ["Rek Sai"],
+      "aliases": []
+    },
+    {
+      "question": "Rell.png",
+      "answers": ["Rell"],
+      "aliases": []
+    },
+    {
+      "question": "Renata.png",
+      "answers": ["Renata Glasc"],
+      "aliases": []
+    },
+    {
+      "question": "Renekton.png",
+      "answers": ["Renekton"],
+      "aliases": []
+    },
+    {
+      "question": "Rengar.png",
+      "answers": ["Rengar"],
+      "aliases": []
+    },
+    {
+      "question": "Riven.png",
+      "answers": ["Riven"],
+      "aliases": []
+    },
+    {
+      "question": "Rumble.png",
+      "answers": ["Rumble"],
+      "aliases": []
+    },
+    {
+      "question": "Ryze.png",
+      "answers": ["Ryze"],
+      "aliases": []
+    },
+    {
+      "question": "Samira.png",
+      "answers": ["Samira"],
+      "aliases": []
+    },
+    {
+      "question": "Sejuani.png",
+      "answers": ["Sejuani"],
+      "aliases": []
+    },
+    {
+      "question": "Senna.png",
+      "answers": ["Senna"],
+      "aliases": []
+    },
+    {
+      "question": "Seraphine.png",
+      "answers": ["Seraphine"],
+      "aliases": []
+    },
+    {
+      "question": "Sett.png",
+      "answers": ["Sett"],
+      "aliases": []
+    },
+    {
+      "question": "Shaco.png",
+      "answers": ["Shaco"],
+      "aliases": []
+    },
+    {
+      "question": "Shen.png",
+      "answers": ["Shen"],
+      "aliases": []
+    },
+    {
+      "question": "Shyvana.png",
+      "answers": ["Shyvana"],
+      "aliases": []
+    },
+    {
+      "question": "Singed.png",
+      "answers": ["Singed"],
+      "aliases": []
+    },
+    {
+      "question": "Sion.png",
+      "answers": ["Sion"],
+      "aliases": []
+    },
+    {
+      "question": "Sivir.png",
+      "answers": ["Sivir"],
+      "aliases": []
+    },
+    {
+      "question": "Skarner.png",
+      "answers": ["Skarner"],
+      "aliases": []
+    },
+    {
+      "question": "Smolder.png",
+      "answers": ["Smolder"],
+      "aliases": []
+    },
+    {
+      "question": "Sona.png",
+      "answers": ["Sona"],
+      "aliases": []
+    },
+    {
+      "question": "Soraka.png",
+      "answers": ["Soraka"],
+      "aliases": []
+    },
+    {
+      "question": "Swain.png",
+      "answers": ["Swain"],
+      "aliases": []
+    },
+    {
+      "question": "Sylas.png",
+      "answers": ["Sylas"],
+      "aliases": []
+    },
+    {
+      "question": "Syndra.png",
+      "answers": ["Syndra"],
+      "aliases": []
+    },
+    {
+      "question": "TahmKench.png",
+      "answers": ["Tahm Kench"],
+      "aliases": []
+    },
+    {
+      "question": "Taliyah.png",
+      "answers": ["Taliyah"],
+      "aliases": []
+    },
+    {
+      "question": "Talon.png",
+      "answers": ["Talon"],
+      "aliases": []
+    },
+    {
+      "question": "Taric.png",
+      "answers": ["Taric"],
+      "aliases": []
+    },
+    {
+      "question": "Teemo.png",
+      "answers": ["Teemo"],
+      "aliases": []
+    },
+    {
+      "question": "Thresh.png",
+      "answers": ["Thresh"],
+      "aliases": []
+    },
+    {
+      "question": "Tristana.png",
+      "answers": ["Tristana"],
+      "aliases": []
+    },
+    {
+      "question": "Trundle.png",
+      "answers": ["Trundle"],
+      "aliases": []
+    },
+    {
+      "question": "Tryndamere.png",
+      "answers": ["Tryndamere"],
+      "aliases": []
+    },
+    {
+      "question": "TwistedFate.png",
+      "answers": ["Twisted Fate"],
+      "aliases": []
+    },
+    {
+      "question": "Twitch.png",
+      "answers": ["Twitch"],
+      "aliases": []
+    },
+    {
+      "question": "Udyr.png",
+      "answers": ["Udyr"],
+      "aliases": []
+    },
+    {
+      "question": "Urgot.png",
+      "answers": ["Urgot"],
+      "aliases": []
+    },
+    {
+      "question": "Varus.png",
+      "answers": ["Varus"],
+      "aliases": []
+    },
+    {
+      "question": "Vayne.png",
+      "answers": ["Vayne"],
+      "aliases": []
+    },
+    {
+      "question": "Veigar.png",
+      "answers": ["Veigar"],
+      "aliases": []
+    },
+    {
+      "question": "Velkoz.png",
+      "answers": ["Vel Koz"],
+      "aliases": []
+    },
+    {
+      "question": "Vex.png",
+      "answers": ["Vex"],
+      "aliases": []
+    },
+    {
+      "question": "Vi.png",
+      "answers": ["Vi"],
+      "aliases": []
+    },
+    {
+      "question": "Viego.png",
+      "answers": ["Viego"],
+      "aliases": []
+    },
+    {
+      "question": "Viktor.png",
+      "answers": ["Viktor"],
+      "aliases": []
+    },
+    {
+      "question": "Vladimir.png",
+      "answers": ["Vladimir"],
+      "aliases": []
+    },
+    {
+      "question": "Volibear.png",
+      "answers": ["Volibear"],
+      "aliases": []
+    },
+    {
+      "question": "Warwick.png",
+      "answers": ["Warwick"],
+      "aliases": []
+    },
+    {
+      "question": "Xayah.png",
+      "answers": ["Xayah"],
+      "aliases": []
+    },
+    {
+      "question": "Xerath.png",
+      "answers": ["Xerath"],
+      "aliases": []
+    },
+    {
+      "question": "XinZhao.png",
+      "answers": ["Xin Zhao"],
+      "aliases": []
+    },
+    {
+      "question": "Yasuo.png",
+      "answers": ["Yasuo"],
+      "aliases": []
+    },
+    {
+      "question": "Yone.png",
+      "answers": ["Yone"],
+      "aliases": []
+    },
+    {
+      "question": "Yorick.png",
+      "answers": ["Yorick"],
+      "aliases": []
+    },
+    {
+      "question": "Yuumi.png",
+      "answers": ["Yuumi"],
+      "aliases": []
+    },
+    {
+      "question": "Zac.png",
+      "answers": ["Zac"],
+      "aliases": []
+    },
+    {
+      "question": "Zed.png",
+      "answers": ["Zed"],
+      "aliases": []
+    },
+    {
+      "question": "Zeri.png",
+      "answers": ["Zeri"],
+      "aliases": []
+    },
+    {
+      "question": "Ziggs.png",
+      "answers": ["Ziggs"],
+      "aliases": []
+    },
+    {
+      "question": "Zilean.png",
+      "answers": ["Zilean"],
+      "aliases": []
+    },
+    {
+      "question": "Zoe.png",
+      "answers": ["Zoe"],
+      "aliases": []
+    },
+    {
+      "question": "Zyra.png",
+      "answers": ["Zyra"],
+      "aliases": []
+    }
+  ]
+}

--- a/frontend/public/category_preview_list.json
+++ b/frontend/public/category_preview_list.json
@@ -1,9 +1,24 @@
 {
   "category_previews": [
     {
+      "name": "Brand Logos",
+      "image": "default-preview.png",
+      "desc": "Guess the brand by their logo!"
+    },
+    {
+      "name": "LoL Champion Covers",
+      "image": "default-preview.png",
+      "desc": "Guess the LoL champion's name by their image!"
+    },
+    {
       "name": "LoL Champion Titles",
       "image": "default-preview.png",
       "desc": "Guess the LoL champion's name by their title!"
+    },
+    {
+      "name": "Numbers",
+      "image": "default-preview.png",
+      "desc": "Test your Number Skillz"
     }
   ]
 }


### PR DESCRIPTION
## Description of Change

I added a script to main that will automatically scan every file under backend/src/scripts and create a category file (or two, if they take a QuestionType) under public/category_data. I also had to reformat some stuff like brand_icons to work with this format. 

## Motivation and Context

[https://github.com/apnguyen1/floor-it/issues/72]

## Current behavior

Manually importing every category then calling to_file() on it

## New Behavior

![image](https://github.com/user-attachments/assets/7fe368ba-f389-46df-a3fe-5e8e73b26b1d)

## How Has This Been Tested?

Just debugging it until it works, then checking the outputted jsons to make sure they look correct, but that mostly just depends on if the to_file() function is working properly