### PR TITLE
(qol) default input without mic

### DIFF
--- a/frontend/src/components/Settings/SettingModal.tsx
+++ b/frontend/src/components/Settings/SettingModal.tsx
@@ -47,6 +47,8 @@ interface SettingModalProps {
   ) => void;
   /** Current use text input state */
   useTextInput: boolean;
+  /** Whether there is an error trying to use speech recognition or not */
+  isSpeechError: boolean;
 }
 
 export const SettingModal = ({
@@ -56,6 +58,7 @@ export const SettingModal = ({
   useSharedTimer: initialUseSharedTimer,
   useTextInput,
   onSave,
+  isSpeechError,
 }: SettingModalProps) => {
   const [playerSettings, setPlayerSettings] = useState({ ...players });
   const [sharedTimer, setSharedTimer] = useState(initialUseSharedTimer);
@@ -227,15 +230,17 @@ export const SettingModal = ({
             </>
           )}
 
-          <FormControlLabel
-            control={
-              <Switch
-                checked={localUseTextInput}
-                onChange={(e) => setLocalUseTextInput(e.target.checked)}
-              />
-            }
-            label="Enable Text Input (in addition to voice)"
-          />
+          {!isSpeechError && (
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={localUseTextInput}
+                  onChange={(e) => setLocalUseTextInput(e.target.checked)}
+                />
+              }
+              label="Enable Text Input (in addition to voice)"
+            />
+          )}
         </Box>
 
         <Box sx={actionButtonContainer()}>

--- a/frontend/src/hooks/useSpeechCommands.ts
+++ b/frontend/src/hooks/useSpeechCommands.ts
@@ -116,7 +116,7 @@ export const useSpeechCommands = (
 
   return {
     transcript,
-    listening,
+    listening: listening && !errorMessage,
     hasError: !!errorMessage,
     errorMessage,
   };

--- a/frontend/src/screens/Game/GameScreen.tsx
+++ b/frontend/src/screens/Game/GameScreen.tsx
@@ -106,7 +106,7 @@ export const GameScreen = () => {
       winRef.current.pause();
     }
     setShowWinningModal(false);
-  }, []);
+  }, [hasError]);
 
   /**
    * Handles the end of a trivia game
@@ -132,7 +132,7 @@ export const GameScreen = () => {
       }
       setShowWinningModal(true);
     },
-    [players.P1.name, players.P2.name],
+    [players.P1.name, players.P2.name, hasError],
   );
 
   /**
@@ -195,7 +195,7 @@ export const GameScreen = () => {
     if (winRef.current) {
       winRef.current.pause();
     }
-  }, [setScreen]);
+  }, [setScreen, hasError]);
 
   /**
    * Opens the settings modal

--- a/frontend/src/screens/Game/GameScreen.tsx
+++ b/frontend/src/screens/Game/GameScreen.tsx
@@ -324,6 +324,7 @@ export const GameScreen = () => {
         useSharedTimer={useSharedTimer}
         useTextInput={useTextInput}
         onSave={handleSaveSettings}
+        isSpeechError={hasError}
       />
     </Box>
   );

--- a/frontend/src/screens/Game/GameScreen.tsx
+++ b/frontend/src/screens/Game/GameScreen.tsx
@@ -79,6 +79,10 @@ export const GameScreen = () => {
     isTyping,
   );
 
+  if (hasError) {
+    setUseTextInput(true);
+  }
+
   /**
    * Handles the start of a trivia game
    *

--- a/frontend/src/screens/Game/GameScreen.tsx
+++ b/frontend/src/screens/Game/GameScreen.tsx
@@ -97,9 +97,11 @@ export const GameScreen = () => {
       inGame: true,
       winner: undefined,
     }));
-    SpeechRecognition.startListening({
-      continuous: true,
-    }).catch((e) => console.error('Speech Recognition failed: ', e));
+    if (!hasError) {
+      SpeechRecognition.startListening({
+        continuous: true,
+      }).catch((e) => console.error('Speech Recognition failed: ', e));
+    }
     if (winRef.current) {
       winRef.current.pause();
     }
@@ -121,7 +123,9 @@ export const GameScreen = () => {
         inGame: false,
         winner: playerName === players.P1.name ? players.P2.name : players.P1.name,
       }));
-      SpeechRecognition.abortListening().catch((e) => console.error(e));
+      if (!hasError) {
+        SpeechRecognition.abortListening().catch((e) => console.error(e));
+      }
       if (winRef.current) {
         winRef.current.currentTime = 0;
         winRef.current.play().catch((e) => console.error(e));
@@ -185,7 +189,9 @@ export const GameScreen = () => {
       inGame: false,
     }));
     setScreen(ScreenType.Categories);
-    SpeechRecognition.abortListening().catch((e) => console.error(e));
+    if (!hasError) {
+      SpeechRecognition.abortListening().catch((e) => console.error(e));
+    }
     if (winRef.current) {
       winRef.current.pause();
     }

--- a/frontend/src/screens/Game/components/Display/Display.test.tsx
+++ b/frontend/src/screens/Game/components/Display/Display.test.tsx
@@ -66,10 +66,19 @@ describe('Display', () => {
 
   it('should render error message when hasError is true', () => {
     const errorMessage = 'Something went wrong!';
-    render(<Display {...mockProps} hasError={true} errorMessage={errorMessage} />);
-
+    render(
+      <Display
+        {...mockProps}
+        inGame={true}
+        hasError={true}
+        errorMessage={errorMessage}
+      />,
+    );
+    screen.debug();
     expect(screen.getByText('Error')).toBeInTheDocument();
-    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    expect(
+      screen.getByText(errorMessage + ' Defaulting to text input.'),
+    ).toBeInTheDocument();
   });
 
   it('should render GamePreview when not in game', () => {

--- a/frontend/src/screens/Game/components/Display/Display.tsx
+++ b/frontend/src/screens/Game/components/Display/Display.tsx
@@ -6,6 +6,7 @@ import {
   CircularProgress,
   TextField,
   Typography,
+  Snackbar,
 } from '@mui/material';
 import TriviaQuestion from './GameDisplay/TriviaQuestion.tsx';
 import { GamePreview } from './GamePreview/GamePreview.tsx';
@@ -82,6 +83,18 @@ export const Display = ({
   onSkipCategory,
 }: DisplayProps) => {
   const [textAnswer, setTextAnswer] = useState('');
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+
+  // Show snackbar when there's an error
+  useEffect(() => {
+    if (hasError) {
+      setOpenSnackbar(true);
+    }
+  }, [hasError]);
+
+  const handleCloseSnackbar = () => {
+    setOpenSnackbar(false);
+  };
 
   // Clear the text input when the current question changes, either from text or voice
   useEffect(() => {
@@ -115,85 +128,94 @@ export const Display = ({
   }
 
   return (
-    <Box className="question-box" sx={questionBox()}>
-      {categoryProgress && category && (
-        <Chip
-          icon={<CategoryIcon />}
-          label={`(${categoryProgress.current}/${categoryProgress.total})`}
-          sx={categoryChip()}
-        />
+    <>
+      {/* Render Snackbar for error message */}
+      {hasError && (
+        <Snackbar
+          open={openSnackbar}
+          autoHideDuration={4000} // Auto hide after 4 seconds
+          onClose={handleCloseSnackbar}
+        >
+          <Alert onClose={handleCloseSnackbar} variant="filled" severity="error">
+            <AlertTitle>Error</AlertTitle>
+            {errorMessage + ' Defaulting to text input.'}
+          </Alert>
+        </Snackbar>
       )}
-      {!inGame && category ? (
-        <GamePreview
-          category={category}
-          categoryProgress={categoryProgress}
-          onStartGame={onStartGame}
-          onSkipCategory={onSkipCategory}
-        />
-      ) : (
-        <>
-          <Box className={'question-content'} sx={questionContent()}>
-            {isSkipped && currentQuestion ? (
-              <Box className={'skip-penalty'} sx={skipPenalty()}>
-                <TimerOffIcon sx={{ fontSize: 50, color: '#f44336' }} />
-                <Typography variant="h4" color="error" fontWeight="bold">
-                  Skip Penalty!
-                </Typography>
-                <Typography variant="subtitle1">The correct answer is:</Typography>
-                <Typography variant="h3" color="primary.main" fontWeight="bold">
-                  {currentQuestion.answers[0]}
-                </Typography>
-              </Box>
-            ) : (
-              currentQuestion &&
-              category && (
-                <TriviaQuestion
-                  type={category.type}
-                  question={currentQuestion.question}
-                />
-              )
+      <Box className="question-box" sx={questionBox()}>
+        {categoryProgress && category && (
+          <Chip
+            icon={<CategoryIcon />}
+            label={`(${categoryProgress.current}/${categoryProgress.total})`}
+            sx={categoryChip()}
+          />
+        )}
+        {!inGame && category ? (
+          <GamePreview
+            category={category}
+            categoryProgress={categoryProgress}
+            onStartGame={onStartGame}
+            onSkipCategory={onSkipCategory}
+          />
+        ) : (
+          <>
+            <Box className={'question-content'} sx={questionContent()}>
+              {isSkipped && currentQuestion ? (
+                <Box className={'skip-penalty'} sx={skipPenalty()}>
+                  <TimerOffIcon sx={{ fontSize: 50, color: '#f44336' }} />
+                  <Typography variant="h4" color="error" fontWeight="bold">
+                    Skip Penalty!
+                  </Typography>
+                  <Typography variant="subtitle1">The correct answer is:</Typography>
+                  <Typography variant="h3" color="primary.main" fontWeight="bold">
+                    {currentQuestion.answers[0]}
+                  </Typography>
+                </Box>
+              ) : (
+                currentQuestion &&
+                category && (
+                  <TriviaQuestion
+                    type={category.type}
+                    question={currentQuestion.question}
+                  />
+                )
+              )}
+            </Box>
+            {useTextInput && (
+              <TextField
+                autoFocus={hasError}
+                onFocus={handleTextInputFocus}
+                onBlur={handleTextInputBlur}
+                value={textAnswer}
+                onChange={handleTextChange}
+                placeholder="Type your answer..."
+                fullWidth
+                sx={textInput()}
+              />
             )}
-          </Box>
-          {useTextInput && (
-            <TextField
-              autoFocus={hasError}
-              onFocus={handleTextInputFocus}
-              onBlur={handleTextInputBlur}
-              value={textAnswer}
-              onChange={handleTextChange}
-              placeholder="Type your answer..."
-              fullWidth
-              sx={textInput()}
-            />
-          )}
-          {
-            // Render an error box instead of the transcript if speech recognition cannot be used
-            hasError ? (
-              <Box sx={{ ...transcriptBox(), overflow: 'hidden' }}>
-                <Alert variant="filled" severity="error">
-                  <AlertTitle>Error</AlertTitle>
-                  {errorMessage + ' Defaulting to text input.'}
-                </Alert>
-              </Box>
-            ) : (
-              <Typography
-                variant="subtitle2"
-                color="textSecondary"
-                sx={transcriptBox()}
-              >
-                <strong>You said:</strong> {transcript || 'Waiting for your answer...'}
+            {
+              // Render an error box instead of the transcript if speech recognition cannot be used
+              !hasError && (
+                <Typography
+                  variant="subtitle2"
+                  color="textSecondary"
+                  sx={transcriptBox()}
+                >
+                  <strong>You said:</strong>{' '}
+                  {transcript || 'Waiting for your answer...'}
+                </Typography>
+              )
+            }
+            <Box className={'help-text'} sx={helpText()}>
+              <SpaceBarIcon fontSize="small" />
+              <Typography>
+                Press <strong>Space/Esc</strong> or say <strong>Next</strong> to skip
+                question
               </Typography>
-            )
-          }
-          <Box className={'help-text'} sx={helpText()}>
-            <SpaceBarIcon fontSize="small" />
-            <Typography>
-              Press <strong>Space/Esc</strong> or say <strong>Next</strong> to skip
-              question
-            </Typography>
-          </Box>
-        </>
-      )}
-    </Box>
+            </Box>
+          </>
+        )}
+      </Box>
+    </>
   );
 };

--- a/frontend/src/screens/Game/components/Display/Display.tsx
+++ b/frontend/src/screens/Game/components/Display/Display.tsx
@@ -171,7 +171,7 @@ export const Display = ({
               <Box sx={{ ...transcriptBox(), overflow: 'hidden' }}>
                 <Alert variant="filled" severity="error">
                   <AlertTitle>Error</AlertTitle>
-                  {errorMessage + ' Defaulting to fallback text input.'}
+                  {errorMessage + ' Defaulting to text input.'}
                 </Alert>
               </Box>
             ) : (

--- a/frontend/src/screens/Game/components/Display/Display.tsx
+++ b/frontend/src/screens/Game/components/Display/Display.tsx
@@ -169,10 +169,7 @@ export const Display = ({
           {
             // Render an error box instead of the transcript if speech recognition cannot be used
             hasError ? (
-              <Box
-                data-testid="error-box"
-                sx={{ ...transcriptBox(), overflow: 'hidden' }}
-              >
+              <Box sx={{ ...transcriptBox(), overflow: 'hidden' }}>
                 <Alert variant="filled" severity="error">
                   <AlertTitle>Error</AlertTitle>
                   {errorMessage + ' Defaulting to text input.'}

--- a/frontend/src/screens/Game/components/Display/Display.tsx
+++ b/frontend/src/screens/Game/components/Display/Display.tsx
@@ -168,7 +168,7 @@ export const Display = ({
           {
             // Render an error box instead of the transcript if speech recognition cannot be used
             hasError ? (
-              <Box sx={transcriptBox()}>
+              <Box sx={{ ...transcriptBox(), overflow: 'hidden' }}>
                 <Alert variant="filled" severity="error">
                   <AlertTitle>Error</AlertTitle>
                   {errorMessage + ' Defaulting to fallback text input.'}

--- a/frontend/src/screens/Game/components/Display/Display.tsx
+++ b/frontend/src/screens/Game/components/Display/Display.tsx
@@ -154,8 +154,9 @@ export const Display = ({
               )
             )}
           </Box>
-          {useTextInput && ( // TODO: set autoFocus when voice recognition is not supported
+          {useTextInput && (
             <TextField
+              autoFocus={hasError}
               onFocus={handleTextInputFocus}
               onBlur={handleTextInputBlur}
               value={textAnswer}
@@ -168,7 +169,10 @@ export const Display = ({
           {
             // Render an error box instead of the transcript if speech recognition cannot be used
             hasError ? (
-              <Box sx={{ ...transcriptBox(), overflow: 'hidden' }}>
+              <Box
+                data-testid="error-box"
+                sx={{ ...transcriptBox(), overflow: 'hidden' }}
+              >
                 <Alert variant="filled" severity="error">
                   <AlertTitle>Error</AlertTitle>
                   {errorMessage + ' Defaulting to text input.'}

--- a/frontend/src/screens/Game/components/Display/Display.tsx
+++ b/frontend/src/screens/Game/components/Display/Display.tsx
@@ -114,18 +114,6 @@ export const Display = ({
     );
   }
 
-  // Show an error alert if an error has occurred
-  if (hasError) {
-    return (
-      <Box sx={questionBox()}>
-        <Alert variant="filled" severity="error">
-          <AlertTitle>Error</AlertTitle>
-          {errorMessage}
-        </Alert>
-      </Box>
-    );
-  }
-
   return (
     <Box className="question-box" sx={questionBox()}>
       {categoryProgress && category && (
@@ -177,13 +165,25 @@ export const Display = ({
               sx={textInput()}
             />
           )}
-          <Typography
-            variant={'subtitle2'}
-            color={'textSecondary'}
-            sx={transcriptBox()}
-          >
-            <strong>You said:</strong> {transcript || 'Waiting for your answer...'}
-          </Typography>
+          {
+            // Render an error box instead of the transcript if speech recognition cannot be used
+            hasError ? (
+              <Box sx={transcriptBox()}>
+                <Alert variant="filled" severity="error">
+                  <AlertTitle>Error</AlertTitle>
+                  {errorMessage + ' Defaulting to fallback text input.'}
+                </Alert>
+              </Box>
+            ) : (
+              <Typography
+                variant="subtitle2"
+                color="textSecondary"
+                sx={transcriptBox()}
+              >
+                <strong>You said:</strong> {transcript || 'Waiting for your answer...'}
+              </Typography>
+            )
+          }
           <Box className={'help-text'} sx={helpText()}>
             <SpaceBarIcon fontSize="small" />
             <Typography>

--- a/frontend/src/screens/Game/components/Display/Display.tsx
+++ b/frontend/src/screens/Game/components/Display/Display.tsx
@@ -209,8 +209,16 @@ export const Display = ({
             <Box className={'help-text'} sx={helpText()}>
               <SpaceBarIcon fontSize="small" />
               <Typography>
-                Press <strong>Space/Esc</strong> or say <strong>Next</strong> to skip
-                question
+                {!hasError ? (
+                  <>
+                    Press <strong>Space/Esc</strong> or say <strong>Next</strong> to
+                    skip question
+                  </>
+                ) : (
+                  <>
+                    Press <strong>Esc</strong> to skip question
+                  </>
+                )}
               </Typography>
             </Box>
           </>


### PR DESCRIPTION
## Description of Change

Changed text box to be rendered by default when speech recognition cannot be used (unsupported browser or no mic permissions)
Changed error box to render where the transcript would be, instead of blocking the game entirely
Added a sentence to the error message explaining that it is defaulting to text input

## Motivation and Context

https://github.com/apnguyen1/floor-it/issues/182

## Current behavior

When mic is off or using an unsupported browser an error box renders instead of any content and the game is unplayable

## New Behavior

![image](https://github.com/user-attachments/assets/7ccb6d9c-1a8c-4900-9885-e1ea7dc34e98)
Testing in firefox which is not supported by speech recognition
![image](https://github.com/user-attachments/assets/45859b43-5efa-48e6-a713-304aab83470e)
Testing in chrome but not giving mic permissions
Additionally, the text box is changed to be enabled by default when there is an error
## How Has This Been Tested?
Playtesting changes
